### PR TITLE
fix: split on correct newline character

### DIFF
--- a/src/js/bulk.js
+++ b/src/js/bulk.js
@@ -19,7 +19,7 @@ bulkAddForm.addEventListener("submit", (event) => {
 
   switch (delineator) {
     case "newline": {
-      names = students.split("\r\n");
+      names = students.split("\n");
       break;
     }
     case "comma": {


### PR DESCRIPTION
This PR alters the split argument to correctly divide students by line.

Fixes #32